### PR TITLE
 A test case for loops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ jspm_packages
 
 # Optional npm cache directory
 .npm
+yarn.lock
 
 # Optional REPL history
 .node_repl_history

--- a/test/components/with-loops.riot
+++ b/test/components/with-loops.riot
@@ -1,0 +1,26 @@
+<my-component>
+  <h2>With Loops</h2>
+  <div>
+    <span each={item in state.nested.items}>{item}</span>
+    <p each={item in state.items}>{item}</p>
+  </div>
+  <script>
+    export default {
+      state: {
+        nested: {}
+      },
+      insertItems(){
+        this.update({
+          items:[1,2,3,4,5]
+        })
+      },
+      insertNestedItems(){
+        this.update({
+          nested:{
+            items:[1,2,3,4,5]
+          }
+        })
+      }
+    }
+  </script>
+</my-component>

--- a/test/index.js
+++ b/test/index.js
@@ -59,4 +59,21 @@ describe('@riotjs/hydrate', () => {
     expect(beforeSpy).to.have.been.called
     expect(afterSpy).to.have.been.called
   })
+
+  it('it works with loops', () => {
+    const WithLoops = require('./components/with-loops.riot').default
+    const root = document.createElement('div')
+    root.innerHTML = '<h2>With Loops</h2><div></div>'
+
+    document.body.appendChild(root)
+    const instance = hydrate(WithLoops)(root)
+
+    instance.insertItems()
+    expect(root.querySelectorAll('p').length).to.be.equal(5)
+
+    instance.insertNestedItems()
+    expect(root.querySelectorAll('span').length).to.be.equal(5)
+  })
+
+
 })


### PR DESCRIPTION
In some cases hydrate function works incorrectly with loops. 

#### This test case produces following error:
```
1) @riotjs/hydrate
       it works with loops:
     TypeError: Cannot read property 'ownerDocument' of null
      at append (node_modules/riot/riot.js:334:31)
      at domdiff (node_modules/riot/riot.js:637:7)
      at Object.update (node_modules/riot/riot.js:734:7)
      at bindings.forEach.b (node_modules/riot/riot.js:1493:36)
      at Array.forEach (<anonymous>)
      at Object.update (node_modules/riot/riot.js:1493:21)
      at Object.update (node_modules/riot/riot.js:2019:35)
      at Object.insertItems (test/components/with-loops.riot:15:12)
      at Context.it (test/index.js:71:14)
      at process.topLevelDomainCallback (domain.js:120:23)

``` 

##### In the browser it can produce following errors:
1. 
```
Uncaught (in promise) TypeError: Cannot read property 'insertBefore' of null
    at swap (index.js:195684)
    at Object.update (index.js:195648)
    at index.js:196227
    at Array.forEach (<anonymous>)
    at Object.update (index.js:196227)
    at Object.update (index.js:196753)
    at Object.join (index.js:247)
```
2.
```
index.js:195067 Uncaught (in promise) TypeError: Cannot read property 'insertBefore' of null
    at append (index.js:195067)
    at domdiff (index.js:195371)
    at Object.update (index.js:195468)
    at index.js:196227
    at Array.forEach (<anonymous>)
    at Object.update (index.js:196227)
    at Object.update (index.js:196316)
    at index.js:196394
    at Array.forEach (<anonymous>)
    at Object.update (index.js:196394)
```